### PR TITLE
Match documentation

### DIFF
--- a/gxref.el
+++ b/gxref.el
@@ -369,7 +369,10 @@ a GTAGS file is found.  See `gxref-set-project-dir' for more details."
 ;;;###autoload
 (defun gxref-xref-backend ()
   "Gxref backend for Xref."
-  'gxref)
+  (when (or gxref-project-root-dir
+            (gxref--find-project-root))
+    'gxref)
+  )
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql gxref)))
   (let ((current-symbol (symbol-at-point)))

--- a/gxref.el
+++ b/gxref.el
@@ -180,15 +180,23 @@ If not defined, 'global -p' will be used to find it."
 
 ;;;###autoload
 (defcustom gxref-gtags-conf nil
-  "Explicit GTAGS/GLOBAL configuration file.")
+  "Explicit GTAGS/GLOBAL configuration file."
+  :type '(radio (const :tag "None" nil)
+                file)
+  :safe 'file-name-absolute-p)
 
 ;;;###autoload
 (defcustom gxref-gtags-label nil
-  "Explicit GTAGS/GLOBAL label.")
+  "Explicit GTAGS/GLOBAL label."
+  :type '(radio (const :tag "None" nil)
+                string))
 
 ;;;###autoload
 (defcustom gxref-gtags-lib-path nil
-  "Explicit GLOBAL libpath.")
+  "Explicit GLOBAL libpath."
+  :type '(radio (const :tag "None" nil)
+                 directory)
+  :safe 'directory-name-p)
 
 
 


### PR DESCRIPTION
This makes gxref return nil when it should not be used, so that it can be used as in the documentation: (add-to-list 'xref-backend-functions 'gxref-xref-backend) without shadowing for example the elisp backend.

Also add types to the defcustoms to remove some byte compiler warnings. (I'm not entirely sure about this as I don't use customize myself).